### PR TITLE
Avoid conflicting workflows for Renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,4 +1,5 @@
 name: Renovate
+concurrency: renovate
 on:
   # Allows manual/automated ad-hoc trigger
   workflow_dispatch:


### PR DESCRIPTION
Set a `concurrency` key with a name to avoid running multiple jobs at the same time